### PR TITLE
fix: categoria visivel no Vote + erro onOpenSnackBar

### DIFF
--- a/src/components/Vote/CompetitorCard.tsx
+++ b/src/components/Vote/CompetitorCard.tsx
@@ -87,20 +87,20 @@ export default function CompetitorCard({
             >
               {user.name}
             </Typography>
-            <Typography variant="body2" sx={{ color: "#8AC6D0", opacity: 0.8 }}>
+            <Typography variant="body2" sx={{ color: "#8AC6D0", opacity: 0.8, mb: 0.5 }}>
               {user.work}
             </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                color: "#8AC6D0",
+                fontWeight: 600,
+                fontSize: "1rem",
+              }}
+            >
+              {user.category}
+            </Typography>
           </Box>
-          <Chip
-            label={user.category}
-            icon={<StarIcon />}
-            sx={{
-              background: "rgba(138, 198, 208, 0.2)",
-              color: "#8AC6D0",
-              border: "1px solid rgba(138, 198, 208, 0.3)",
-              fontWeight: 600,
-            }}
-          />
         </Box>
 
         {/* Critérios de Votação */}

--- a/src/pages/Vote/Vote.tsx
+++ b/src/pages/Vote/Vote.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { IUser } from "../Register/Register";
 import { Box, Grid, Typography, Container, Skeleton } from "@mui/material";
 import PageHeader from "@/components/Vote/PageHeader";
 import CompetitorCard from "@/components/Vote/CompetitorCard";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 
 interface VoteValuesState {
   anatomy: number;
@@ -15,12 +16,17 @@ interface VoteValuesState {
 }
 
 interface VoteProps {
-  onOpenSnackBar: (message: string) => void;
+  onOpenSnackBar?: (message: string) => void;
   users?: IUser[] | [];
   setUsers?: (users: IUser[]) => void;
 }
 
 export default function Vote({ onOpenSnackBar }: VoteProps) {
+  const { showSnackbar } = useSnackbar();
+  const notify = useCallback((msg: string) => {
+    if (onOpenSnackBar) onOpenSnackBar(msg);
+    else showSnackbar(msg);
+  }, [onOpenSnackBar, showSnackbar]);
   const [totalScoreSum, setTotalScoreSum] = useState(0);
   const [loading, setLoading] = useState<boolean>(false);
   const [users, setUsers] = useState<IUser[]>([]);
@@ -52,14 +58,14 @@ export default function Vote({ onOpenSnackBar }: VoteProps) {
         setTotalScoreSum(total);
       } catch (error) {
         console.error("Erro ao buscar dados:", error);
-        onOpenSnackBar("Erro ao listar competidores");
+        notify("Erro ao listar competidores");
       } finally {
         setLoading(false);
       }
     };
 
     fetchUsers();
-  }, [onOpenSnackBar]);
+  }, [notify]);
 
   const handleSliderChange =
     (name: string) => (event: Event, value: number | number[]) => {
@@ -113,10 +119,10 @@ export default function Vote({ onOpenSnackBar }: VoteProps) {
         visualImpact: 5,
         category: "",
       });
-      onOpenSnackBar("Voto registrado com sucesso! 🎉");
+      notify("Voto registrado com sucesso! 🎉");
     } catch (error) {
       console.error("Erro ao votar:", error);
-      onOpenSnackBar("Erro ao registrar voto");
+      notify("Erro ao registrar voto");
     } finally {
       setLoading(false);
       setVotingUserId(null);


### PR DESCRIPTION
**NOTA:** Este PR depende do PR #28 (snackbar global) — rebaseado em cima dele.

## O que foi feito

**Categoria maior no card de votacao**
- Antes: categoria era um Chip pequeno ao lado do nome
- Agora: Typography body1 com fontWeight 600 abaixo do trabalho — mesmo destaque visual do nome do competidor

**Corrigido erro 'onOpenSnackBar is not a function'**
- Vote.tsx usava onOpenSnackBar obrigatorio como prop
- Quando acessado como pagina direta (/Vote/Vote), a prop nao existia
- Agora: aceita opcional + usa useSnackbar() como fallback