### PR TITLE
fix: loop infinito de GET /api/list no Vote

### DIFF
--- a/src/pages/Vote/Vote.tsx
+++ b/src/pages/Vote/Vote.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IUser } from "../Register/Register";
 import { Box, Grid, Typography, Container, Skeleton } from "@mui/material";
 import PageHeader from "@/components/Vote/PageHeader";
 import CompetitorCard from "@/components/Vote/CompetitorCard";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 
 interface VoteValuesState {
   anatomy: number;
@@ -15,15 +16,12 @@ interface VoteValuesState {
 }
 
 interface VoteProps {
-  onOpenSnackBar?: (message: string) => void;
   users?: IUser[] | [];
   setUsers?: (users: IUser[]) => void;
 }
 
-export default function Vote({ onOpenSnackBar }: VoteProps) {
-  function notify(msg: string) {
-    if (onOpenSnackBar) onOpenSnackBar(msg);
-  }
+export default function Vote({ users: initialUsers, setUsers: setParentUsers }: VoteProps) {
+  const { showSnackbar } = useSnackbar();
   const [totalScoreSum, setTotalScoreSum] = useState(0);
   const [loading, setLoading] = useState<boolean>(false);
   const [users, setUsers] = useState<IUser[]>([]);
@@ -55,14 +53,14 @@ export default function Vote({ onOpenSnackBar }: VoteProps) {
         setTotalScoreSum(total);
       } catch (error) {
         console.error("Erro ao buscar dados:", error);
-        notify("Erro ao listar competidores");
+        showSnackbar("Erro ao listar competidores");
       } finally {
         setLoading(false);
       }
     };
 
     fetchUsers();
-  }, [notify]);
+  }, [showSnackbar]);
 
   const handleSliderChange =
     (name: string) => (event: Event, value: number | number[]) => {
@@ -116,10 +114,10 @@ export default function Vote({ onOpenSnackBar }: VoteProps) {
         visualImpact: 5,
         category: "",
       });
-      notify("Voto registrado com sucesso! 🎉");
+      showSnackbar("Voto registrado com sucesso! 🎉");
     } catch (error) {
       console.error("Erro ao votar:", error);
-      notify("Erro ao registrar voto");
+      showSnackbar("Erro ao registrar voto");
     } finally {
       setLoading(false);
       setVotingUserId(null);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -329,7 +329,6 @@ function App() {
             >
               {currentPage === "vote" && (
                 <Vote
-                  onOpenSnackBar={handleOpenSnackBar}
                   users={users}
                   setUsers={setUsers}
                 />


### PR DESCRIPTION
## Causa do bug

O PR #31 criou um **loop infinito**:

```
notify() recriada a cada render
  → useEffect dispara (notify muda)
    → fetchUsers() com GET /api/list
      → setUsers() atualiza estado
        → rerender do componente
          → notify() recriada de novo
            → useEffect dispara... infinito
```

Isso gerava dezenas de requisições `GET /api/list 304` por segundo.

## Correcao

- Agora que o SnackbarContext ja ta na master (PR #28), Vote usa
  `useSnackbar()` direto em vez de receber `onOpenSnackBar` como prop
- Remove a funcao `notify()` que causava o loop
- Remove a prop `onOpenSnackBar` do index.tsx
- `showSnackbar` do contexto é estável (criado com useCallback) — não
  causa re-renders

Pode aprovar este PR #32, depois fechar/ignorar o PR #30 (ja coberto pelo #28).