### PR TITLE
fix: voto independente por competidor

### DIFF
--- a/src/components/Vote/CompetitorCard.tsx
+++ b/src/components/Vote/CompetitorCard.tsx
@@ -3,33 +3,16 @@ import {
   CardContent,
   Typography,
   Box,
-  Chip,
   Grid,
   Button,
 } from "@mui/material";
-import { Star as StarIcon } from "@mui/icons-material";
+import { useState } from "react";
 import VotingCriteria from "./VotingCriteria";
 import ScoreDisplay from "./ScoreDisplay";
-
-interface VoteValuesState {
-  anatomy: number;
-  creativity: number;
-  pigmentation: number;
-  traces: number;
-  readability: number;
-  visualImpact: number;
-  category: string;
-}
+import { useSnackbar } from "@/contexts/SnackbarContext";
 
 interface CompetitorCardProps {
   user: any;
-  voteValues: VoteValuesState;
-  totalScoreSum: number;
-  votingUserId: string | null;
-  onSliderChange: (
-    name: string
-  ) => (event: Event, value: number | number[]) => void;
-  onVote: (userId: string) => void;
 }
 
 const criteriaConfig = [
@@ -41,14 +24,65 @@ const criteriaConfig = [
   { name: "visualImpact", label: "Impacto Visual", icon: "⚡" },
 ];
 
-export default function CompetitorCard({
-  user,
-  voteValues,
-  totalScoreSum,
-  votingUserId,
-  onSliderChange,
-  onVote,
-}: CompetitorCardProps) {
+const DEFAULT_SLIDER = 5;
+
+export default function CompetitorCard({ user }: CompetitorCardProps) {
+  const { showSnackbar } = useSnackbar();
+  const [voteValues, setVoteValues] = useState<Record<string, number>>({
+    anatomy: DEFAULT_SLIDER,
+    creativity: DEFAULT_SLIDER,
+    pigmentation: DEFAULT_SLIDER,
+    traces: DEFAULT_SLIDER,
+    readability: DEFAULT_SLIDER,
+    visualImpact: DEFAULT_SLIDER,
+  });
+  const [voting, setVoting] = useState(false);
+
+  const handleSliderChange =
+    (name: string) => (event: Event, value: number | number[]) => {
+      setVoteValues((prev) => ({ ...prev, [name]: value as number }));
+    };
+
+  const handleVote = async () => {
+    setVoting(true);
+    try {
+      const payload = {
+        anatomy: voteValues.anatomy,
+        creativity: voteValues.creativity,
+        pigmentation: voteValues.pigmentation,
+        traces: voteValues.traces,
+        readability: voteValues.readability,
+        visualImpact: voteValues.visualImpact,
+      };
+
+      const response = await fetch("/api/vote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...payload, competidorId: user._id }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Erro ao registrar voto");
+      }
+
+      setVoteValues({
+        anatomy: DEFAULT_SLIDER,
+        creativity: DEFAULT_SLIDER,
+        pigmentation: DEFAULT_SLIDER,
+        traces: DEFAULT_SLIDER,
+        readability: DEFAULT_SLIDER,
+        visualImpact: DEFAULT_SLIDER,
+      });
+
+      showSnackbar("Voto registrado com sucesso! 🎉");
+    } catch (error) {
+      console.error("Erro ao votar:", error);
+      showSnackbar("Erro ao registrar voto");
+    } finally {
+      setVoting(false);
+    }
+  };
+
   return (
     <Card
       sx={{
@@ -109,35 +143,30 @@ export default function CompetitorCard({
             <Grid item xs={12} md={6} key={criteria.name}>
               <VotingCriteria
                 criteria={criteria}
-                value={
-                  voteValues[criteria.name as keyof VoteValuesState] as number
-                }
-                onChange={onSliderChange(criteria.name)}
+                value={voteValues[criteria.name] as number}
+                onChange={handleSliderChange(criteria.name)}
               />
             </Grid>
           ))}
         </Grid>
 
         {/* Pontuação Atual */}
-        <ScoreDisplay
-          totalScore={user.totalScore}
-          totalScoreSum={totalScoreSum}
-        />
+        <ScoreDisplay totalScore={user.totalScore} />
 
         {/* Botão de Votar */}
         <Button
           variant="contained"
           fullWidth
           size="large"
-          onClick={() => onVote(user._id)}
-          disabled={votingUserId === user._id}
+          onClick={handleVote}
+          disabled={voting}
           sx={{
             py: 1.5,
             fontSize: "1.1rem",
             fontWeight: 600,
           }}
         >
-          {votingUserId === user._id ? "Enviando..." : "Confirmar Voto"}
+          {voting ? "Enviando..." : "Confirmar Voto"}
         </Button>
       </CardContent>
     </Card>

--- a/src/components/Vote/ScoreDisplay.tsx
+++ b/src/components/Vote/ScoreDisplay.tsx
@@ -2,14 +2,12 @@ import { Box, LinearProgress, Typography } from "@mui/material";
 
 interface ScoreDisplayProps {
   totalScore: number;
-  totalScoreSum: number;
 }
 
-export default function ScoreDisplay({
-  totalScore,
-  totalScoreSum,
-}: ScoreDisplayProps) {
-  const percentage = totalScoreSum > 0 ? (totalScore / totalScoreSum) * 100 : 0;
+const MAX_POSSIBLE_SCORE = 10 * 6; // 6 criterios, max 10 cada
+
+export default function ScoreDisplay({ totalScore }: ScoreDisplayProps) {
+  const percentage = (totalScore / MAX_POSSIBLE_SCORE) * 100;
 
   return (
     <Box
@@ -49,7 +47,7 @@ export default function ScoreDisplay({
           fontWeight: 600,
         }}
       >
-        {totalScore} pontos ({percentage.toFixed(2)}%)
+        {totalScore} / {MAX_POSSIBLE_SCORE} pontos
       </Typography>
     </Box>
   );

--- a/src/pages/Vote/Vote.tsx
+++ b/src/pages/Vote/Vote.tsx
@@ -1,40 +1,18 @@
-import { useCallback, useEffect, useState } from "react";
-import { IUser } from "../Register/Register";
+import { useEffect, useState } from "react";
 import { Box, Grid, Typography, Container, Skeleton } from "@mui/material";
 import PageHeader from "@/components/Vote/PageHeader";
 import CompetitorCard from "@/components/Vote/CompetitorCard";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 
-interface VoteValuesState {
-  anatomy: number;
-  creativity: number;
-  pigmentation: number;
-  traces: number;
-  readability: number;
-  visualImpact: number;
-  category: string;
-}
-
 interface VoteProps {
-  users?: IUser[] | [];
-  setUsers?: (users: IUser[]) => void;
+  users?: any[];
+  setUsers?: (users: any[]) => void;
 }
 
 export default function Vote({ users: initialUsers, setUsers: setParentUsers }: VoteProps) {
   const { showSnackbar } = useSnackbar();
-  const [totalScoreSum, setTotalScoreSum] = useState(0);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [users, setUsers] = useState<IUser[]>([]);
-  const [voteValues, setVoteValues] = useState<VoteValuesState>({
-    anatomy: 5,
-    creativity: 5,
-    pigmentation: 5,
-    traces: 5,
-    readability: 5,
-    visualImpact: 5,
-    category: "",
-  });
-  const [votingUserId, setVotingUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [users, setUsers] = useState<any[]>([]);
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -46,11 +24,6 @@ export default function Vote({ users: initialUsers, setUsers: setParentUsers }: 
         }
         const data = await response.json();
         setUsers(data);
-        const total = data.reduce(
-          (acc: number, user: { totalScore: number }) => acc + user.totalScore,
-          0
-        );
-        setTotalScoreSum(total);
       } catch (error) {
         console.error("Erro ao buscar dados:", error);
         showSnackbar("Erro ao listar competidores");
@@ -61,68 +34,6 @@ export default function Vote({ users: initialUsers, setUsers: setParentUsers }: 
 
     fetchUsers();
   }, [showSnackbar]);
-
-  const handleSliderChange =
-    (name: string) => (event: Event, value: number | number[]) => {
-      setVoteValues((prevValues) => ({
-        ...prevValues,
-        [name]: value as number,
-      }));
-    };
-
-  const handleVote = async (userId: string) => {
-    setVotingUserId(userId);
-
-    try {
-      setLoading(true);
-      const payload = {
-        anatomy: voteValues.anatomy,
-        creativity: voteValues.creativity,
-        pigmentation: voteValues.pigmentation,
-        traces: voteValues.traces,
-        readability: voteValues.readability,
-        visualImpact: voteValues.visualImpact,
-      };
-
-      const response = await fetch("/api/vote", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...payload, competidorId: userId }),
-      });
-      if (!response.ok) {
-        throw new Error("Erro ao registrar voto");
-      }
-      const updatedUser = await response.json();
-      const updatedUsers = users.map((user: any) =>
-        user._id === updatedUser._id ? { ...user, ...updatedUser } : user
-      );
-
-      setUsers(updatedUsers);
-      const newTotalScore = updatedUsers.reduce(
-        (acc, user) => acc + user.totalScore,
-        0
-      );
-      setTotalScoreSum(newTotalScore);
-
-      // Reset para valores médios
-      setVoteValues({
-        anatomy: 5,
-        creativity: 5,
-        pigmentation: 5,
-        traces: 5,
-        readability: 5,
-        visualImpact: 5,
-        category: "",
-      });
-      showSnackbar("Voto registrado com sucesso! 🎉");
-    } catch (error) {
-      console.error("Erro ao votar:", error);
-      showSnackbar("Erro ao registrar voto");
-    } finally {
-      setLoading(false);
-      setVotingUserId(null);
-    }
-  };
 
   if (loading && users.length === 0)
     return (
@@ -159,14 +70,7 @@ export default function Vote({ users: initialUsers, setUsers: setParentUsers }: 
           {users.length > 0 ? (
             users.map((user: any) => (
               <Grid item xs={12} key={user._id}>
-                <CompetitorCard
-                  user={user}
-                  voteValues={voteValues}
-                  totalScoreSum={totalScoreSum}
-                  votingUserId={votingUserId}
-                  onSliderChange={handleSliderChange}
-                  onVote={handleVote}
-                />
+                <CompetitorCard user={user} />
               </Grid>
             ))
           ) : (


### PR DESCRIPTION
## O problema

Cada card de votacao compartilhava o mesmo estado `voteValues`.
Quando o usuario mexia num slider do card A, o card B tambem mudava.

`totalScoreSum` era a soma GLOBAL de todos os competidores, entao
a barra de progresso de um card mudava quando outro card recebia voto.

## A correcao

**Cada card vota independente:**
- `CompetitorCard` agora tem estado LOCAL dos sliders (useState)
- `handleVote` movido pra dentro do card — cada card chama a API
- `ScoreDisplay` calcula % sobre a pontuacao maxima (60 pontos)
- `Vote.tsx` simplificado — so lista os cards, sem estado compartilhado

**Top100 e Listagem:**
- Cada Competidor ja e um registro independente (1 trabalho + 1 categoria)
- Top100 ordena por totalScore individual — cada trabalho concorre separado
- Filtro por categoria funciona corretamente
- Nao precisa de ajustes