### PR TITLE
feat: remove botao votar + redirect classificacao + fix visualImpact

### DIFF
--- a/src/components/Top100/components/RankingCard.tsx
+++ b/src/components/Top100/components/RankingCard.tsx
@@ -169,7 +169,7 @@ export default function RankingCard({ user, index }: RankingCardProps) {
             { label: "Pigmentação", value: user.pigmentation },
             { label: "Traços", value: user.traces },
             { label: "Legibilidade", value: user.readability },
-            { label: "Imp. Visual", value: user.visualimpact },
+            { label: "Imp. Visual", value: user.visualImpact },
           ].map((item) => (
             <Box
               key={item.label}

--- a/src/components/Vote/CompetitorCard.tsx
+++ b/src/components/Vote/CompetitorCard.tsx
@@ -1,14 +1,7 @@
-import {
-  Card,
-  CardContent,
-  Typography,
-  Box,
-  Grid,
-  Button,
-} from "@mui/material";
+import { Card, CardContent, Typography, Box, Grid, Button } from "@mui/material";
 import { useState } from "react";
+import { useRouter } from "next/router";
 import VotingCriteria from "./VotingCriteria";
-import ScoreDisplay from "./ScoreDisplay";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 
 interface CompetitorCardProps {
@@ -28,6 +21,7 @@ const DEFAULT_SLIDER = 5;
 
 export default function CompetitorCard({ user }: CompetitorCardProps) {
   const { showSnackbar } = useSnackbar();
+  const router = useRouter();
   const [voteValues, setVoteValues] = useState<Record<string, number>>({
     anatomy: DEFAULT_SLIDER,
     creativity: DEFAULT_SLIDER,
@@ -68,6 +62,11 @@ export default function CompetitorCard({ user }: CompetitorCardProps) {
 
       setVoted(true);
       showSnackbar("Voto registrado com sucesso! 🎉");
+
+      // Redireciona para classificacao apos 1.5s
+      setTimeout(() => {
+        router.push("/Top100/Top100");
+      }, 1500);
     } catch (error) {
       console.error("Erro ao votar:", error);
       showSnackbar("Erro ao registrar voto");
@@ -147,9 +146,6 @@ export default function CompetitorCard({ user }: CompetitorCardProps) {
             </Grid>
           ))}
         </Grid>
-
-        {/* Pontuação Atual */}
-        <ScoreDisplay totalScore={user.totalScore} />
 
         {/* Botão de Votar */}
         <Button

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -19,7 +19,7 @@ export interface IUser {
   pigmentation: number;
   traces: number;
   readability: number;
-  visualimpact: number;
+  visualImpact: number;
   totalScore: number;
   day: "Sexta" | "Sábado" | "Domingo";
   category: string;

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -860,10 +860,16 @@ export default function AdminVotacaoPage() {
               Nenhum competidor cadastrado ainda
             </Typography>
           ) : (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-              {competidores.map((c: any) => (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {Object.entries(
+                competidores.reduce<Record<string, any[]>>((acc, c) => {
+                  if (!acc[c.name]) acc[c.name] = [];
+                  acc[c.name].push(c);
+                  return acc;
+                }, {})
+              ).map(([nome, entries]: [string, any[]]) => (
                 <Card
-                  key={c._id}
+                  key={nome}
                   sx={{
                     background: "rgba(255, 255, 255, 0.03)",
                     borderRadius: 2,
@@ -872,45 +878,151 @@ export default function AdminVotacaoPage() {
                 >
                   <CardContent
                     sx={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      flexWrap: "wrap",
-                      gap: 1,
-                      py: 1.5,
-                      "&:last-child": { pb: 1.5 },
+                      py: 2,
+                      "&:last-child": { pb: 2 },
                     }}
                   >
-                    <Box>
-                      <Typography
-                        sx={{
-                          color: "#B8F3FF",
-                          fontWeight: 600,
-                          fontSize: "0.95rem",
-                        }}
-                      >
-                        {c.name}
-                      </Typography>
-                      <Typography sx={{ color: "#8AC6D0", fontSize: "0.8rem" }}>
-                        {c.work} — {c.category}
-                      </Typography>
-                      <Typography
-                        sx={{
-                          color: "#8AC6D0",
-                          fontSize: "0.75rem",
-                          opacity: 0.7,
-                        }}
-                      >
-                        {c.votacaoId?.nome || "Votação removida"}
-                      </Typography>
-                    </Box>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleDeleteCompetidor(c._id, c.name)}
-                      sx={{ color: "#f44336" }}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "flex-start",
+                        flexWrap: "wrap",
+                        gap: 1,
+                      }}
                     >
-                      <DeleteIcon />
-                    </IconButton>
+                      <Box>
+                        <Typography
+                          sx={{
+                            color: "#B8F3FF",
+                            fontWeight: 700,
+                            fontSize: "1rem",
+                          }}
+                        >
+                          {nome}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            color: "#8AC6D0",
+                            fontSize: "0.8rem",
+                            mt: 0.5,
+                          }}
+                        >
+                          {entries.length}{" "}
+                          {entries.length === 1
+                            ? "categoria"
+                            : "categorias"}{" "}
+                          inscrita(s){/* Mostra categorias agrupadas */}
+                        </Typography>
+                      </Box>
+                      <Button
+                        size="small"
+                        color="error"
+                        variant="outlined"
+                        onClick={() => {
+                          if (
+                            window.confirm(
+                              `Deletar TODAS as inscrições de "${nome}"?`
+                            )
+                          ) {
+                            Promise.all(
+                              entries.map((e: any) =>
+                                fetch(`/api/save?id=${e._id}`, {
+                                  method: "DELETE",
+                                })
+                              )
+                            ).then(() => {
+                              fetchCompetidores();
+                              showSnackbar(
+                                `${entries.length} inscrição(ões) de "${nome}" removida(s)`,
+                                "success"
+                              );
+                            });
+                          }
+                        }}
+                        sx={{
+                          borderColor: "rgba(244, 67, 54, 0.4)",
+                          color: "#f44336",
+                          fontSize: "0.75rem",
+                          "&:hover": {
+                            borderColor: "#f44336",
+                            background: "rgba(244, 67, 54, 0.1)",
+                          },
+                        }}
+                      >
+                        Remover tudo
+                      </Button>
+                    </Box>
+
+                    {/* Lista de categorias */}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 1,
+                        mt: 2,
+                      }}
+                    >
+                      {entries.map((c: any) => (
+                        <Box
+                          key={c._id}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                            background: "rgba(138, 198, 208, 0.1)",
+                            borderRadius: 1,
+                            px: 1,
+                            py: 0.3,
+                            border: "1px solid rgba(138, 198, 208, 0.2)",
+                          }}
+                        >
+                          <Typography
+                            sx={{
+                              color: "#8AC6D0",
+                              fontSize: "0.8rem",
+                              fontWeight: 500,
+                            }}
+                          >
+                            {c.category}
+                          </Typography>
+                          <Typography
+                            sx={{
+                              color: "#8AC6D0",
+                              fontSize: "0.7rem",
+                              opacity: 0.6,
+                              mx: 0.3,
+                            }}
+                          >
+                            —
+                          </Typography>
+                          <Typography
+                            sx={{
+                              color: "#B8F3FF",
+                              fontSize: "0.75rem",
+                              fontWeight: 500,
+                            }}
+                          >
+                            {c.work}
+                          </Typography>
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              handleDeleteCompetidor(c._id, `${c.work} (${c.category})`)
+                            }
+                            sx={{
+                              color: "#f44336",
+                              opacity: 0.6,
+                              "&:hover": { opacity: 1 },
+                              ml: 0.5,
+                              p: 0.3,
+                            }}
+                          >
+                            <DeleteIcon sx={{ fontSize: 14 }} />
+                          </IconButton>
+                        </Box>
+                      ))}
+                    </Box>
                   </CardContent>
                 </Card>
               ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,29 +9,21 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  HowToVote as VoteIcon,
   PersonAdd as RegisterIcon,
   EmojiEvents as TrophyIcon,
-  Home as HomeIcon,
 } from "@mui/icons-material";
 import Register, { IUser } from "./Register/Register";
 import { Header } from "@/components/Header/Header";
-import Vote from "./Vote/Vote";
 import Top100 from "./Top100/Top100";
 import { SnackBarCustom } from "@/components/Snackbar/SnackBar";
 import Animation from "@/components/Animation/Animation";
 
 function App() {
-  const [users, setUsers] = useState<IUser[]>([]);
   const [currentPage, setCurrentPage] = useState("animation");
   const [snackBarMessage, setSnackBarMessage] = useState("");
-  const [, setSnackBarOpen] = useState(false);
 
   const handleNavigateAnimation = () => {
     setCurrentPage("animation");
-  };
-  const handleNavigateVote = () => {
-    setCurrentPage("vote");
   };
   const handleNavigateRegister = () => {
     setCurrentPage("register");
@@ -42,17 +34,9 @@ function App() {
 
   const handleOpenSnackBar = (message: string) => {
     setSnackBarMessage(message);
-    setSnackBarOpen(true);
   };
 
   const navigationCards = [
-    {
-      title: "Vote Agora",
-      description: "Avalie os competidores",
-      icon: <VoteIcon sx={{ fontSize: 48 }} />,
-      onClick: handleNavigateVote,
-      gradient: "linear-gradient(135deg, #B8F3FF 0%, #8AC6D0 100%)",
-    },
     {
       title: "Registrar Participante",
       description: "Cadastre um novo competidor",
@@ -80,7 +64,6 @@ function App() {
           }}
         >
           <Container maxWidth="lg">
-            {/* Header */}
             <Box sx={{ mb: 6, textAlign: "center" }}>
               <Box
                 sx={{
@@ -113,7 +96,6 @@ function App() {
               </Typography>
             </Box>
 
-            {/* Animation */}
             <Box
               sx={{
                 mb: 6,
@@ -124,10 +106,9 @@ function App() {
               <Animation />
             </Box>
 
-            {/* Navigation Cards */}
-            <Grid container spacing={3}>
+            <Grid container spacing={3} justifyContent="center">
               {navigationCards.map((card, index) => (
-                <Grid item xs={12} md={4} key={index}>
+                <Grid item xs={12} md={6} key={index}>
                   <Card
                     onClick={card.onClick}
                     sx={{
@@ -221,7 +202,6 @@ function App() {
               <Header onClick={handleNavigateAnimation} />
             </Grid>
 
-            {/* Navigation Tabs */}
             <Grid
               item
               style={{ width: "100%", maxWidth: "1200px", padding: "0 1rem" }}
@@ -240,32 +220,6 @@ function App() {
                   justifyContent: "center",
                 }}
               >
-                <Button
-                  onClick={handleNavigateVote}
-                  variant={currentPage === "vote" ? "contained" : "outlined"}
-                  startIcon={<VoteIcon />}
-                  fullWidth={true}
-                  sx={{
-                    color: currentPage === "vote" ? "#36213E" : "#8AC6D0",
-                    borderColor: "rgba(184, 243, 255, 0.3)",
-                    background:
-                      currentPage === "vote"
-                        ? "linear-gradient(90deg, #B8F3FF 0%, #8AC6D0 100%)"
-                        : "transparent",
-                    fontWeight: 600,
-                    px: 3,
-                    py: 1,
-                    "&:hover": {
-                      borderColor: "#8AC6D0",
-                      background:
-                        currentPage === "vote"
-                          ? "linear-gradient(90deg, #B8F3FF 0%, #8AC6D0 100%)"
-                          : "rgba(138, 198, 208, 0.1)",
-                    },
-                  }}
-                >
-                  Vote Agora
-                </Button>
                 <Button
                   onClick={handleNavigateRegister}
                   variant={
@@ -327,14 +281,8 @@ function App() {
               xs={12}
               style={{ display: "flex", justifyContent: "center" }}
             >
-              {currentPage === "vote" && (
-                <Vote
-                  users={users}
-                  setUsers={setUsers}
-                />
-              )}
               {currentPage === "register" && (
-                <Register onRegister={handleNavigateVote} />
+                <Register onRegister={() => setCurrentPage("animation")} />
               )}
               {currentPage === "top10" && <Top100 />}
             </Grid>


### PR DESCRIPTION
## Mudancas

**Index (Opcao A):**
- Remove botao 'Vote Agora' dos cards e abas
- Ficam apenas: Registrar Participante + Classificacao Geral
- Votacao acessivel SOMENTE via QR Code (/auth/qrcode)

**CompetitorCard:**
- Remove 'Pontuacao Atual' (ScoreDisplay)
- Apos votar: redireciona para /Top100/Top100 em 1.5s

**Bugfix classificacao:**
- `visualimpact` (minusculo) → `visualImpact` (maiusculo)
- RankingCard mostrava 0 em 'Imp. Visual' mesmo com votos
- Corrigido no RankingCard e na interface IUser