### PR TITLE
fix: melhorias mobile + paginacao + tattoo theme

### DIFF
--- a/src/components/Vote/PageHeader.tsx
+++ b/src/components/Vote/PageHeader.tsx
@@ -32,7 +32,7 @@ export default function PageHeader() {
         Avalie cada critério de 0 a 10 usando os controles deslizantes
       </Typography>
       <Link
-        href="/voting-rules"
+        href="/rules"
         target="_blank"
         sx={{
           display: "inline-flex",

--- a/src/components/Vote/VotingCriteria.tsx
+++ b/src/components/Vote/VotingCriteria.tsx
@@ -18,7 +18,7 @@ export default function VotingCriteria({
   return (
     <Box
       sx={{
-        p: 2,
+        p: { xs: 1.5, sm: 2 },
         borderRadius: 2,
         background: "rgba(255, 255, 255, 0.03)",
         border: "1px solid rgba(184, 243, 255, 0.1)",
@@ -29,7 +29,7 @@ export default function VotingCriteria({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
-          mb: 1,
+          mb: 1.5,
         }}
       >
         <Typography
@@ -40,21 +40,29 @@ export default function VotingCriteria({
             display: "flex",
             alignItems: "center",
             gap: 1,
+            fontSize: { xs: "0.85rem", sm: "0.875rem" },
           }}
         >
           <span style={{ fontSize: "1.2rem" }}>{criteria.icon}</span>
           {criteria.label}
         </Typography>
-        <Chip
-          label={value}
-          size="small"
+        <Box
           sx={{
             background: "linear-gradient(45deg, #B8F3FF 30%, #8AC6D0 90%)",
             color: "#36213E",
             fontWeight: 700,
-            minWidth: 40,
+            borderRadius: 1,
+            minWidth: 36,
+            height: 32,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: "0.9rem",
+            px: 1,
           }}
-        />
+        >
+          {value}
+        </Box>
       </Box>
       <Slider
         value={value}
@@ -69,26 +77,33 @@ export default function VotingCriteria({
         ]}
         sx={{
           color: "#8AC6D0",
+          py: { xs: 1, sm: 0 },
           "& .MuiSlider-thumb": {
+            width: { xs: 32, sm: 24 },
+            height: { xs: 32, sm: 24 },
             background: "linear-gradient(45deg, #B8F3FF 30%, #8AC6D0 90%)",
             boxShadow: "0 2px 8px rgba(184, 243, 255, 0.4)",
             "&:hover, &.Mui-focusVisible": {
-              boxShadow: "0 0 0 8px rgba(184, 243, 255, 0.16)",
+              boxShadow: "0 0 0 10px rgba(184, 243, 255, 0.16)",
             },
           },
           "& .MuiSlider-track": {
+            height: { xs: 8, sm: 6 },
             background: "linear-gradient(90deg, #B8F3FF 0%, #8AC6D0 100%)",
             border: "none",
           },
           "& .MuiSlider-rail": {
+            height: { xs: 8, sm: 6 },
             background: "rgba(184, 243, 255, 0.2)",
           },
           "& .MuiSlider-mark": {
+            width: 2,
+            height: { xs: 8, sm: 6 },
             background: "rgba(184, 243, 255, 0.4)",
           },
           "& .MuiSlider-markLabel": {
             color: "#8AC6D0",
-            fontSize: "0.75rem",
+            fontSize: { xs: "0.75rem", sm: "0.75rem" },
           },
         }}
       />

--- a/src/pages/Vote/Vote.tsx
+++ b/src/pages/Vote/Vote.tsx
@@ -11,7 +11,10 @@ import {
   DialogContent,
   DialogActions,
   keyframes,
+  LinearProgress,
+  MobileStepper,
 } from "@mui/material";
+import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
 import PageHeader from "@/components/Vote/PageHeader";
 import CompetitorCard from "@/components/Vote/CompetitorCard";
 import { useSnackbar } from "@/contexts/SnackbarContext";
@@ -33,8 +36,10 @@ export default function Vote() {
   const [loading, setLoading] = useState(false);
   const [users, setUsers] = useState<any[]>([]);
   const [votados, setVotados] = useState<Set<string>>(new Set());
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [finalizado, setFinalizado] = useState(false);
+  const topRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -58,11 +63,32 @@ export default function Vote() {
   }, [showSnackbar]);
 
   const handleVoteComplete = useCallback((id: string) => {
-    setVotados((prev) => new Set(prev).add(id));
+    setVotados((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
   }, []);
 
-  const todosVotados = users.length > 0 && votados.size === users.length;
-  const pendentes = users.length - votados.size;
+  const allVoted = users.length > 0 && votados.size === users.length;
+  const votedCount = votados.size;
+  const totalCount = users.length;
+  const currentUser = users[currentIndex];
+  const isCurrentVoted = currentUser ? votados.has(currentUser._id) : false;
+
+  const goToNext = () => {
+    if (currentIndex < users.length - 1) {
+      setCurrentIndex((i) => i + 1);
+      topRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  const goToPrev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex((i) => i - 1);
+      topRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  };
 
   const handleFinalizar = () => {
     setConfirmOpen(true);
@@ -71,7 +97,6 @@ export default function Vote() {
   const confirmarFinalizar = async () => {
     setConfirmOpen(false);
 
-    // Marca QR como finalizado
     if (code && typeof code === "string") {
       try {
         await fetch("/api/qrcodes/finalizar", {
@@ -86,7 +111,6 @@ export default function Vote() {
 
     setFinalizado(true);
 
-    // Redireciona para classificacao apos festejar
     setTimeout(() => {
       router.push("/Top100/Top100");
     }, 3500);
@@ -117,12 +141,12 @@ export default function Vote() {
       sx={{
         minHeight: "100vh",
         background: "linear-gradient(135deg, #36213E 0%, #554971 100%)",
-        py: { xs: 4, md: 6 },
+        py: { xs: 3, md: 6 },
         position: "relative",
         overflow: "hidden",
       }}
+      ref={topRef}
     >
-      {/* Confetti ao finalizar */}
       {finalizado &&
         confettiChars.map((char, i) => (
           <Box
@@ -144,35 +168,25 @@ export default function Vote() {
       <Container maxWidth="lg">
         <PageHeader />
 
-        {/* Progresso ou celebração */}
         {finalizado ? (
-          <Box
-            sx={{
-              textAlign: "center",
-              py: 4,
-            }}
-          >
+          <Box sx={{ textAlign: "center", py: 4 }}>
             <Typography
               variant="h3"
               sx={{
                 fontWeight: 800,
-                background: "linear-gradient(45deg, #FFD700 30%, #FFA500 90%)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
+                color: "#FFD700",
                 mb: 2,
               }}
             >
-              🎉 Votação Finalizada! 🎉
+              Votação Finalizada!
             </Typography>
-            <Typography
-              variant="h6"
-              sx={{ color: "#8AC6D0", fontWeight: 400 }}
-            >
+            <Typography variant="h6" sx={{ color: "#8AC6D0", fontWeight: 400 }}>
               Redirecionando para a classificação...
             </Typography>
           </Box>
         ) : (
           <>
+            {/* Progress bar */}
             <Box
               sx={{
                 mb: 3,
@@ -180,98 +194,163 @@ export default function Vote() {
                 borderRadius: 2,
                 background: "rgba(255, 255, 255, 0.03)",
                 border: "1px solid rgba(184, 243, 255, 0.1)",
-                textAlign: "center",
               }}
             >
-              <Typography sx={{ color: "#8AC6D0", fontWeight: 500 }}>
-                {votados.size === 0
-                  ? `${users.length} competidor(es) para avaliar`
-                  : `${votados.size} de ${users.length} avaliado(s) — ${pendentes} pendente(s)`}
-              </Typography>
+              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+                <Typography sx={{ color: "#8AC6D0", fontWeight: 500, fontSize: { xs: "0.85rem", sm: "0.95rem" } }}>
+                  {votedCount === 0
+                    ? `${totalCount} competidor(es) para avaliar`
+                    : `${votedCount} de ${totalCount} avaliado(s)`}
+                </Typography>
+                <Typography sx={{ color: "#B8F3FF", fontWeight: 600, fontSize: { xs: "0.85rem", sm: "0.95rem" } }}>
+                  {currentIndex + 1} / {totalCount}
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={(votedCount / Math.max(totalCount, 1)) * 100}
+                sx={{
+                  height: 6,
+                  borderRadius: 3,
+                  background: "rgba(184, 243, 255, 0.1)",
+                  "& .MuiLinearProgress-bar": {
+                    background: "linear-gradient(90deg, #B8F3FF 0%, #8AC6D0 100%)",
+                    borderRadius: 3,
+                  },
+                }}
+              />
             </Box>
 
-            <Grid container spacing={3}>
-              {users.length > 0 ? (
-                users.map((user: any) => (
-                  <Grid item xs={12} key={user._id}>
-                    <CompetitorCard
-                      user={user}
-                      code={code as string}
-                      onVoteComplete={handleVoteComplete}
-                    />
-                  </Grid>
-                ))
-              ) : (
+            {/* Current competitor */}
+            {currentUser && (
+              <Grid container spacing={3}>
                 <Grid item xs={12}>
-                  <Box
-                    sx={{
-                      textAlign: "center",
-                      py: 8,
-                      color: "#8AC6D0",
-                    }}
-                  >
-                    <Typography variant="h6">
-                      Nenhum participante cadastrado
-                    </Typography>
-                  </Box>
+                  <CompetitorCard
+                    user={currentUser}
+                    code={code as string}
+                    onVoteComplete={handleVoteComplete}
+                  />
                 </Grid>
-              )}
-            </Grid>
+              </Grid>
+            )}
 
-            {todosVotados && (
-              <Box sx={{ textAlign: "center", mt: 4, mb: 2 }}>
+            {/* Mobile-style navigation */}
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                mt: 2,
+                gap: 1,
+              }}
+            >
+              <Button
+                variant="outlined"
+                onClick={goToPrev}
+                disabled={currentIndex === 0}
+                startIcon={<KeyboardArrowLeft />}
+                size="small"
+                sx={{ minWidth: { xs: 100, sm: 130 } }}
+              >
+                Anterior
+              </Button>
+
+              {votados.size >= 1 && (
+                <Button
+                  variant="text"
+                  onClick={() => setCurrentIndex(users.findIndex((u) => !votados.has(u._id)))}
+                  size="small"
+                  sx={{ color: "#8AC6D0", fontSize: "0.8rem" }}
+                >
+                  {totalCount - votedCount > 0
+                    ? `Pular p/ pendente (${totalCount - votedCount})`
+                    : "Todos votados"}
+                </Button>
+              )}
+
+              {currentIndex < users.length - 1 ? (
+                <Button
+                  variant="outlined"
+                  onClick={goToNext}
+                  disabled={currentIndex === users.length - 1}
+                  endIcon={<KeyboardArrowRight />}
+                  size="small"
+                  sx={{ minWidth: { xs: 100, sm: 130 } }}
+                >
+                  Próximo
+                </Button>
+              ) : allVoted ? (
                 <Button
                   variant="contained"
-                  size="large"
                   onClick={handleFinalizar}
-                  sx={{
-                    py: 1.5,
-                    px: 6,
-                    fontSize: "1.2rem",
-                    fontWeight: 700,
-                  }}
+                  size="small"
+                  sx={{ minWidth: { xs: 100, sm: 130 } }}
                 >
-                  Finalizar Avaliação
+                  Finalizar
                 </Button>
-              </Box>
-            )}
+              ) : (
+                <Button
+                  variant="outlined"
+                  onClick={goToNext}
+                  disabled
+                  endIcon={<KeyboardArrowRight />}
+                  size="small"
+                  sx={{ minWidth: { xs: 100, sm: 130 } }}
+                >
+                  Próximo
+                </Button>
+              )}
+            </Box>
+
+            {/* Current competitor status chip */}
+            <Box sx={{ textAlign: "center", mt: 2 }}>
+              <Typography
+                sx={{
+                  color: isCurrentVoted ? "#4caf50" : "#FFD700",
+                  fontSize: "0.8rem",
+                  fontWeight: 500,
+                }}
+              >
+                {isCurrentVoted ? "Voto registrado" : "Aguardando voto"}
+              </Typography>
+            </Box>
           </>
         )}
-      </Container>
 
-      <Dialog
-        open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
-        PaperProps={{
-          sx: {
-            background: "#2D1B36",
-            border: "1px solid rgba(184, 243, 255, 0.2)",
-            borderRadius: 3,
-            maxWidth: 400,
-          },
-        }}
-      >
-        <DialogTitle sx={{ color: "#B8F3FF", fontWeight: 600 }}>
-          Finalizar Avaliação?
-        </DialogTitle>
-        <DialogContent>
-          <Typography sx={{ color: "#8AC6D0" }}>
-            Você já votou em todos os competidores. Após finalizar, não será
-            possível voltar para alterar os votos.
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ p: 2, gap: 1 }}>
-          <Button
-            onClick={() => setConfirmOpen(false)}
-            sx={{ color: "#8AC6D0" }}
-          >
-            Cancelar
-          </Button>
-          <Button variant="contained" onClick={confirmarFinalizar}>
-            Sim, Finalizar
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog
+          open={confirmOpen}
+          onClose={() => setConfirmOpen(false)}
+          PaperProps={{
+            sx: {
+              background: "#2D1B36",
+              border: "1px solid rgba(184, 243, 255, 0.2)",
+              borderRadius: 3,
+              maxWidth: 400,
+            },
+          }}
+        >
+          <DialogTitle sx={{ color: "#B8F3FF", fontWeight: 600 }}>
+            Finalizar Avaliação?
+          </DialogTitle>
+          <DialogContent>
+            <Typography sx={{ color: "#8AC6D0" }}>
+              Você já votou em todos os competidores. Após finalizar, não será
+              possível voltar para alterar os votos.
+            </Typography>
+          </DialogContent>
+          <DialogActions sx={{ p: 2, gap: 1 }}>
+            <Button
+              onClick={() => setConfirmOpen(false)}
+              sx={{ color: "#8AC6D0" }}
+            >
+              Cancelar
+            </Button>
+            <Button variant="contained" onClick={confirmarFinalizar}>
+              Sim, Finalizar
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Container>
     </Box>
   );
 }

--- a/src/pages/auth/qrcode.tsx
+++ b/src/pages/auth/qrcode.tsx
@@ -55,7 +55,7 @@ export default function AuthQRCodePage() {
 
           setTimeout(() => {
             router.push("/Vote/Vote?code=" + code);
-          }, 3000);
+          }, 1500);
         } else if (data.error?.includes("expirado")) {
           setStatus("expirado");
           setMessage("Este QR Code expirou.");

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -11,7 +11,7 @@ const criteria = [
 
 const rules = [
   { step: "1", title: "Receba seu QR Code", desc: "O administrador entrega um QR Code único para cada jurado. Escaneie com seu celular." },
-  { step: "2", title: "Valide seu acesso", desc: "Ao escanear, o QR é validado e consumido (uso único). Você será redirecionado para a página de votação." },
+  { step: "2", title: "Valide seu acesso", desc: "Ao escanear, o QR é validado e consumido (uso único). Você será redirecionado para a página de votação. O QR é válido até o último dia do evento." },
   { step: "3", title: "Avalie cada competidor", desc: "Para cada competidor, dê notas de 0 a 10 em 6 critérios: Anatomia, Criatividade, Pigmentação, Traços, Legibilidade e Impacto Visual." },
   { step: "4", title: "Confirme o voto", desc: "Clique em 'Confirmar Voto' para registrar. Após confirmado, não é possível alterar o voto naquele competidor." },
   { step: "5", title: "Finalize sua avaliação", desc: "Após votar em todos os competidores, clique em 'Finalizar Avaliação'. Sua votação será encerrada e você será redirecionado para o ranking." },


### PR DESCRIPTION
## Melhorias Mobile + Tema Tattoo

### O que muda no celular

**1. Slider touch-friendly**
- Thumb aumentou de 24px para 32px no mobile (dedo não erra)
- Track do slider mais grossa: 8px (antes 4px)
- Chip de nota substituído por badge maior (mais legível)
- Padding responsivo entre mobile e desktop

**2. Paginação (1 competidor por vez)**
**Antes:** Todos os competidores na mesma tela — scroll infinito, jurado se perdia.
**Agora:** Um competidor por vez, com navegação "Anterior / Próximo" + atalho "Pular p/ pendente".
- O jurado foca em um de cada vez
- Menos fadiga, notas mais precisas
- Botão "Finalizar" aparece só quando todos foram votados

**3. Progresso visual**
- Barra de progresso com gradiente (votados vs total)
- Indicador "3 de 20" ao lado
- Status "Voto registrado" / "Aguardando voto" em cada competidor
- Botão "Pular p/ pendente (N)" pra navegação rápida

**4. Outros ajustes**
- QR redirect: 3s → 1.5s (menos espera)
- Gradient text removido (impeccable: banned)
- "Votação Finalizada!" agora usa cor sólida (FFD700) em vez de gradient text

### Sobre o tema Tattoo (sugestões futuras)

O sistema é pra uma competição de tatuagem, mas o visual atual é genérico (roxo/ciano gradiente). Ideias pra deixar com cara de tattoo:

- **Banner ribbon** nos cards de competidor (tipo faixa de "Best In Show" no estilo old school)
- **Papel kraft/textura** como background sutil (referência ao papel de flash tattoo)
- **Tipografia bold** com serifa pra títulos (estilo lettering de tatuagem)
- **Ícones temáticos**: agulha, tinteiro, rosa dos ventos, caveira (ícones MUI ou emoji)
- **Bordas mais marcadas** (traço grosso como outline de tattoo)

Isso da pra implementar numa próxima se quiser. Por enquanto, as cores atuais foram mantidas.

### Build
npx tsc --noEmit + npx next build + npm run lint — tudo OK
