### PR TITLE
feat: registro multi-categoria

### DIFF
--- a/src/components/Register/CategorySelector.tsx
+++ b/src/components/Register/CategorySelector.tsx
@@ -1,25 +1,31 @@
 import {
   Grid,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
   Typography,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
 } from "@mui/material";
 import { Category as CategoryIcon } from "@mui/icons-material";
 
 interface CategorySelectorProps {
   categorias: string[];
-  selectedCategory: string;
-  onCategoryChange: (category: string) => void;
+  selectedCategories: string[];
+  onCategoriesChange: (categories: string[]) => void;
 }
 
 export default function CategorySelector({
   categorias,
-  selectedCategory,
-  onCategoryChange,
+  selectedCategories,
+  onCategoriesChange,
 }: CategorySelectorProps) {
   if (categorias.length === 0) return null;
+
+  const handleToggle = (categoria: string) => {
+    const next = selectedCategories.includes(categoria)
+      ? selectedCategories.filter((c) => c !== categoria)
+      : [...selectedCategories, categoria];
+    onCategoriesChange(next);
+  };
 
   return (
     <>
@@ -36,68 +42,56 @@ export default function CategorySelector({
           }}
         >
           <CategoryIcon />
-          Categoria
+          Categorias
+        </Typography>
+        <Typography sx={{ color: "#8AC6D0", fontSize: "0.85rem", mb: 2 }}>
+          Marque todas as categorias em que o competidor participará.
         </Typography>
       </Grid>
 
       <Grid item xs={12}>
-        <FormControl fullWidth>
-          <InputLabel
-            sx={{
-              color: "#8AC6D0",
-              "&.Mui-focused": {
-                color: "#B8F3FF",
-              },
-            }}
-          >
-            Selecione a Categoria
-          </InputLabel>
-          <Select
-            value={selectedCategory}
-            label="Selecione a Categoria"
-            onChange={(e) => onCategoryChange(e.target.value)}
-            MenuProps={{
-              PaperProps: {
-                sx: {
-                  bgcolor: "#F5F5F5",
-                  "& .MuiMenuItem-root": {
-                    color: "#1a1a1a",
-                    "&:hover": { bgcolor: "rgba(0,0,0,0.08)" },
-                    "&.Mui-selected": {
-                      bgcolor: "rgba(0, 229, 255, 0.15)",
-                      color: "#1a1a1a",
+        <FormGroup>
+          {categorias.map((categoria) => (
+            <FormControlLabel
+              key={categoria}
+              control={
+                <Checkbox
+                  checked={selectedCategories.includes(categoria)}
+                  onChange={() => handleToggle(categoria)}
+                  sx={{
+                    color: "#8AC6D0",
+                    "&.Mui-checked": {
+                      color: "#B8F3FF",
                     },
-                  },
+                  }}
+                />
+              }
+              label={categoria}
+              sx={{
+                color: selectedCategories.includes(categoria) ? "#B8F3FF" : "#8AC6D0",
+                mb: 0.5,
+                "& .MuiFormControlLabel-label": {
+                  fontWeight: selectedCategories.includes(categoria) ? 600 : 400,
                 },
-              },
-            }}
+              }}
+            />
+          ))}
+        </FormGroup>
+      </Grid>
+
+      {selectedCategories.length > 0 && (
+        <Grid item xs={12}>
+          <Typography
             sx={{
-              color: "#B8F3FF",
-              "& .MuiOutlinedInput-notchedOutline": {
-                borderColor: "rgba(184, 243, 255, 0.3)",
-              },
-              "&:hover .MuiOutlinedInput-notchedOutline": {
-                borderColor: "#8AC6D0",
-              },
-              "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                borderColor: "#B8F3FF",
-              },
-              "& .MuiSvgIcon-root": {
-                color: "#8AC6D0",
-              },
+              color: "#4caf50",
+              fontSize: "0.85rem",
+              fontWeight: 500,
             }}
           >
-            <MenuItem value="">
-              <em>-- Escolha uma categoria --</em>
-            </MenuItem>
-            {categorias.map((categoria) => (
-              <MenuItem key={categoria} value={categoria}>
-                {categoria}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Grid>
+            ✅ {selectedCategories.length} categoria(s) selecionada(s)
+          </Typography>
+        </Grid>
+      )}
     </>
   );
 }

--- a/src/components/Register/RegistrationSummary.tsx
+++ b/src/components/Register/RegistrationSummary.tsx
@@ -6,16 +6,16 @@ interface RegistrationSummaryProps {
   name: string;
   work: string;
   votacaoNome: string;
-  category: string;
+  categories: string[];
 }
 
 export default function RegistrationSummary({
   name,
   work,
   votacaoNome,
-  category,
+  categories,
 }: RegistrationSummaryProps) {
-  if (!category) return null;
+  if (categories.length === 0) return null;
 
   return (
     <Grid item xs={12}>
@@ -77,18 +77,23 @@ export default function RegistrationSummary({
           </Box>
           <Box sx={{ display: "flex", justifyContent: "space-between" }}>
             <Typography variant="body2" sx={{ color: "#8AC6D0" }}>
-              Categoria:
+              Categoria(s):
             </Typography>
-            <Chip
-              label={category}
-              size="small"
-              sx={{
-                background: "rgba(138, 198, 208, 0.2)",
-                color: "#8AC6D0",
-                border: "1px solid rgba(138, 198, 208, 0.3)",
-                fontWeight: 600,
-              }}
-            />
+            <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", justifyContent: "flex-end" }}>
+              {categories.map((cat) => (
+                <Chip
+                  key={cat}
+                  label={cat}
+                  size="small"
+                  sx={{
+                    background: "rgba(138, 198, 208, 0.2)",
+                    color: "#8AC6D0",
+                    border: "1px solid rgba(138, 198, 208, 0.3)",
+                    fontWeight: 600,
+                  }}
+                />
+              ))}
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -35,8 +35,8 @@ export default function Register({ onRegister }: IRegisterProps) {
   const [formData, setFormData] = useState({
     name: "",
     work: "",
-    category: "",
   });
+  const [categories, setCategories] = useState<string[]>([]);
   const [, setSnackbarMessage] = useState("");
   const [, setSnackbarSeverity] = useState<
     "success" | "error" | "warning" | "info"
@@ -46,11 +46,12 @@ export default function Register({ onRegister }: IRegisterProps) {
   const [votacaoSelecionadaId, setVotacaoSelecionadaId] = useState<string>("");
   const [categoriasDaVotacao, setCategoriasDaVotacao] = useState<string[]>([]);
   const [activeStep, setActiveStep] = useState(0);
+  const [saving, setSaving] = useState(false);
 
   const steps = [
     "Dados Pessoais",
     "Selecionar Votação",
-    "Selecionar Categoria",
+    "Selecionar Categorias",
   ];
 
   useEffect(() => {
@@ -77,70 +78,72 @@ export default function Register({ onRegister }: IRegisterProps) {
     const votacao = votacoes.find((v) => v._id === votacaoId);
     if (votacao) {
       setCategoriasDaVotacao(votacao.categorias);
-      setFormData((prev) => ({ ...prev, category: "" }));
+      setCategories([]);
       setActiveStep(1);
     } else {
       setCategoriasDaVotacao([]);
     }
   };
 
-  const handleCategoryChange = (categoria: string) => {
-    setFormData((prevState) => ({
-      ...prevState,
-      category: categoria,
-    }));
-    setActiveStep(2);
+  const handleCategoriesChange = (cats: string[]) => {
+    setCategories(cats);
+    if (cats.length > 0) setActiveStep(2);
   };
 
   const handleRegister = async (e: FormEvent) => {
     e.preventDefault();
 
-    if (!votacaoSelecionadaId || !formData.category) {
-      setSnackbarMessage("Por favor, selecione uma votação e uma categoria.");
+    if (!votacaoSelecionadaId || categories.length === 0) {
+      setSnackbarMessage("Por favor, selecione uma votação e pelo menos uma categoria.");
       setSnackbarSeverity("warning");
       setSnackbarOpen(true);
       return;
     }
 
-    try {
-      const response = await fetch("/api/save", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: formData.name,
-          work: formData.work,
-          votacaoId: votacaoSelecionadaId,
-          category: formData.category,
-        }),
-      });
+    setSaving(true);
+    let successCount = 0;
+    let errorCount = 0;
 
-      if (!response.ok) {
-        const error = await response.json();
-        setSnackbarMessage(`Erro ao salvar: ${error.message}`);
-        setSnackbarSeverity("error");
-        setSnackbarOpen(true);
-        return;
+    for (const category of categories) {
+      try {
+        const response = await fetch("/api/save", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: formData.name,
+            work: formData.work,
+            votacaoId: votacaoSelecionadaId,
+            category,
+          }),
+        });
+
+        if (!response.ok) {
+          errorCount++;
+        } else {
+          successCount++;
+        }
+      } catch {
+        errorCount++;
       }
+    }
 
-      const savedUser = await response.json();
-      setSnackbarMessage("Registrado com sucesso!");
-      setSnackbarSeverity("success");
+    setSaving(false);
+
+    if (successCount > 0) {
+      setSnackbarMessage(
+        `Registrado em ${successCount} categoria(s)${errorCount > 0 ? ` (${errorCount} falha(s))` : ""}!`
+      );
+      setSnackbarSeverity(errorCount > 0 ? "warning" : "success");
       setSnackbarOpen(true);
       onRegister();
 
-      // Reset do formulário
-      setFormData({
-        name: "",
-        work: "",
-        category: "",
-      });
+      setFormData({ name: "", work: "" });
+      setCategories([]);
       setVotacaoSelecionadaId("");
       setCategoriasDaVotacao([]);
       setActiveStep(0);
-    } catch (error) {
-      setSnackbarMessage("Erro ao salvar");
+    } else {
+      setSnackbarMessage("Erro ao registrar. Tente novamente.");
       setSnackbarSeverity("error");
       setSnackbarOpen(true);
     }
@@ -192,15 +195,15 @@ export default function Register({ onRegister }: IRegisterProps) {
 
                 <CategorySelector
                   categorias={categoriasDaVotacao}
-                  selectedCategory={formData.category}
-                  onCategoryChange={handleCategoryChange}
+                  selectedCategories={categories}
+                  onCategoriesChange={handleCategoriesChange}
                 />
 
                 <RegistrationSummary
                   name={formData.name}
                   work={formData.work}
                   votacaoNome={votacaoNome}
-                  category={formData.category}
+                  categories={categories}
                 />
 
                 <Grid item xs={12} sx={{ mt: 2 }}>
@@ -210,9 +213,10 @@ export default function Register({ onRegister }: IRegisterProps) {
                     fullWidth
                     size="large"
                     disabled={
+                      saving ||
                       !formData.name ||
                       !votacaoSelecionadaId ||
-                      !formData.category
+                      categories.length === 0
                     }
                     sx={{
                       py: 1.5,
@@ -220,7 +224,9 @@ export default function Register({ onRegister }: IRegisterProps) {
                       fontWeight: 600,
                     }}
                   >
-                    Confirmar Registro
+                    {saving
+                      ? `Registrando em ${categories.length} categoria(s)...`
+                      : `Confirmar Registro (${categories.length} categoria${categories.length > 1 ? "s" : ""})`}
                   </Button>
                 </Grid>
               </Grid>

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1183,10 +1183,10 @@ export default function AdminVotacaoPage() {
                       (v) => v._id === competidorForm.votacaoId
                     )?.nome || ""
                   }
-                  category={
+                  categories={
                     selectedCategoriasCompetidor.length > 0
-                      ? `${selectedCategoriasCompetidor.length} categoria(s)`
-                      : ""
+                      ? selectedCategoriasCompetidor
+                      : []
                   }
                 />
               </Grid>


### PR DESCRIPTION
## O que muda

**Antes:** O seletor de categoria era um dropdown (select único). Só dava pra escolher 1 categoria por registro. Pra participar de 2 categorias, precisava registrar o mesmo competidor 2 vezes.

**Agora:** O seletor virou **checkboxes** — marque quantas categorias quiser de uma vez. O sistema cria um registro pra cada categoria automaticamente no submit.

### Alterações

- **CategorySelector.tsx**: Select → Checkboxes com form group
- **Register.tsx**:  → , submit em loop
- **RegistrationSummary.tsx**: Mostra múltiplos chips em vez de 1 só
- **admin.tsx**: Props atualizadas pro novo formato

### Verificação
- npx tsc --noEmit ✅
- npx next build ✅
- npm run lint ✅